### PR TITLE
fix: Correct add category logic

### DIFF
--- a/add_category.php
+++ b/add_category.php
@@ -10,11 +10,18 @@ $newCategoryHtml = '<div class="category" onclick="navigateTo(\'products\', \'' 
                     <p class="category-subtitle" id="category-count-' . strtolower($newCategory['name']) . '">0 ' . $newCategory['subtitle'] . '</p>
                 </div>';
 
-$indexContent = preg_replace(
-    '/(<section class="categories container">)/',
-    '$1' . $newCategoryHtml,
-    $indexContent
-);
+$dom = new DOMDocument();
+@$dom->loadHTML($indexContent);
+
+$xpath = new DOMXPath($dom);
+$section = $xpath->query('//section[contains(@class, "categories") and contains(@class, "container")]')->item(0);
+
+if ($section) {
+    $fragment = $dom->createDocumentFragment();
+    $fragment->appendXML($newCategoryHtml);
+    $section->appendChild($fragment);
+    $indexContent = $dom->saveHTML();
+}
 
 file_put_contents($indexFile, $indexContent);
 


### PR DESCRIPTION
This commit fixes a bug in the `add_category.php` file where the new category was not being correctly added to the `index.html` file. The `preg_replace` function was replaced with a more reliable method using `DOMDocument` and `DOMXPath` to ensure the new category is always added correctly.